### PR TITLE
DIP-213 job running on bad attribute

### DIFF
--- a/bluekai/job.py
+++ b/bluekai/job.py
@@ -6,23 +6,23 @@ def run(job, writter, config, logger, datalib, converter):
 
     logger.info("start")
 
-    err = None
+    exception = None
 
     try:
 
         do_job(job, writter, config, logger, datalib, converter)
 
-    except Exception as ex:
+    except Exception as catch_exception:
 
-        err = str(ex)
-        logger.error(err)
-        if config['DEBUG']:
-            logger.exception(ex)
+        exception = catch_exception
 
     finally:
-        if err:
-            job.error = err
-            logger.error(err)
+        if exception:
+            error = str(exception)
+            job.error = error
+            logger.error(error)
+            if config['DEBUG']:
+                logger.exception(exception)
         # update db regardless
         job.stop()
         logger.info("end ({} seconds)".format(job.ended - job.started))

--- a/bluekai/models.py
+++ b/bluekai/models.py
@@ -88,6 +88,10 @@ class JobModel(pynamodb.models.Model):
     def error(self):
         return self._error
 
+    @error.setter
+    def error(self, error):
+        self._error = error
+
     @classmethod
     def get(cls, config):
         app_id = cls.appId(config)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -142,13 +142,26 @@ class models_test(TestCase):
 
         self.assertTrue(result)
 
-    def test_running(self):
+    def test_error_getter(self):
+
+        message = "test error message"
 
         job = JobModel()
-        job._error = "test error message"
+        job._error = message
         result = job.error
 
-        self.assertEqual(result, "test error message")
+        self.assertEqual(result, message)
+
+    def test_error_setter(self):
+
+        message = "test error message"
+
+        job = JobModel()
+        job.error = message
+        result = job.error
+
+        self.assertEqual(result, message)
+
 
     @freeze_time(frozen_datetime)
     @patch.object(JobModel, 'save')


### PR DESCRIPTION
The problem was the JobModel.error setter property was not defined and the code in the finally block was crashing before it could stop the job.